### PR TITLE
feat: Enable Auto-Approval & Merge for Dependency PRs from Bots

### DIFF
--- a/.github/workflows/auto-approve-dependency-bots.yml
+++ b/.github/workflows/auto-approve-dependency-bots.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Auto-approve PRs from bots
         uses: hmarr/auto-approve-action@v4
         with:
-          github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ github.event.inputs.pullRequestNumber }}
 
   auto-merge:
@@ -28,6 +28,6 @@ jobs:
       - name: Auto-merge PRs from bots
         uses: pascalgn/automerge-action@v0.16.4
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PULL_REQUEST: ${{ github.event.inputs.pullRequestNumber }}
           MERGE_LABELS: ""

--- a/.github/workflows/auto-approve-dependency-bots.yml
+++ b/.github/workflows/auto-approve-dependency-bots.yml
@@ -1,0 +1,26 @@
+name: Auto Approve and Merge for Dependency Bots
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  auto-approve:
+    if: github.actor == 'dependabot[bot]' || github.actor == 'depfu[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto approve PR
+        uses: hmarr/auto-approve-action@v3
+        with:
+          github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+
+  auto-merge:
+    needs: auto-approve
+    if: github.actor == 'dependabot[bot]' || github.actor == 'depfu[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          merge-method: squash

--- a/.github/workflows/auto-approve-dependency-bots.yml
+++ b/.github/workflows/auto-approve-dependency-bots.yml
@@ -3,24 +3,31 @@ name: Auto Approve and Merge for Dependency Bots
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+  workflow_dispatch:
+    inputs: 
+      pullRequestNumber:
+        description: Pull request number to auto-approve
+        required: true
 
 jobs:
   auto-approve:
-    if: github.actor == 'dependabot[bot]' || github.actor == 'depfu[bot]'
+    if: github.event_name != 'pull_request' || github.actor == 'dependabot[bot]' || github.actor == 'depfu[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Auto approve PR
-        uses: hmarr/auto-approve-action@v3
+      - name: Auto-approve PRs from bots
+        uses: hmarr/auto-approve-action@v4
         with:
-          github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.inputs.pullRequestNumber }}
 
   auto-merge:
+    if: github.event_name != 'pull_request' || github.actor == 'dependabot[bot]' || github.actor == 'depfu[bot]'
     needs: auto-approve
-    if: github.actor == 'dependabot[bot]' || github.actor == 'depfu[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Enable auto-merge
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
-          merge-method: squash
+      - name: Auto-merge PRs from bots
+        uses: pascalgn/automerge-action@v0.16.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_REQUEST: ${{ github.event.inputs.pullRequestNumber }}
+          MERGE_LABELS: ""

--- a/.github/workflows/auto-approve-dependency-bots.yml
+++ b/.github/workflows/auto-approve-dependency-bots.yml
@@ -11,23 +11,23 @@ on:
 
 jobs:
   auto-approve:
-    if: github.event_name != 'pull_request' || github.actor == 'dependabot[bot]' || github.actor == 'depfu[bot]'
+    if: github.event_name != 'pull_request_target' || github.actor == 'dependabot[bot]' || github.actor == 'depfu[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Auto-approve PRs from bots
         uses: hmarr/auto-approve-action@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_ACCESS_TOKEN }}
           pull-request-number: ${{ github.event.inputs.pullRequestNumber }}
 
   auto-merge:
-    if: github.event_name != 'pull_request' || github.actor == 'dependabot[bot]' || github.actor == 'depfu[bot]'
+    if: github.event_name != 'pull_request_target' || github.actor == 'dependabot[bot]' || github.actor == 'depfu[bot]'
     needs: auto-approve
     runs-on: ubuntu-latest
     steps:
       - name: Auto-merge PRs from bots
         uses: pascalgn/automerge-action@v0.16.4
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           PULL_REQUEST: ${{ github.event.inputs.pullRequestNumber }}
           MERGE_LABELS: ""


### PR DESCRIPTION
This workflow automates the approval and merge process for pull requests created by Dependabot and Depfu bots. It ensures dependency updates are merged faster, improving security and keeping the project up to date.

It uses:
- `hmarr/auto-approve-action` to simulate approval.
- `peter-evans/enable-pull-request-automerge` to complete the merge automatically (if checks pass).