### PR TITLE
fix: Use JSON converter for error messages

### DIFF
--- a/Backend/src/ITL.API/ITL.API.csproj
+++ b/Backend/src/ITL.API/ITL.API.csproj
@@ -14,6 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
   </ItemGroup>
 

--- a/Backend/src/ITL.API/Middlewares/ExceptionHandler.cs
+++ b/Backend/src/ITL.API/Middlewares/ExceptionHandler.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace ITL.API.Middlewares;
 
@@ -42,11 +43,8 @@ public class ExceptionHandler
         }
 
         var errorMessage = exception.InnerException?.Message ?? exception.Message;
-
-        // TODO: Use Json converter
-        var jsonMesage = $"{{\"message\": \"{errorMessage}\"}}";
-
-        await context.Response.WriteAsync(jsonMesage);
+        var jsonMessage = JsonConvert.SerializeObject(new { message = errorMessage });
+        await context.Response.WriteAsync(jsonMessage);
     }
 
     public HttpStatusCode GetStatusCode(Exception exception)


### PR DESCRIPTION
Closes #266

- Replaces manual JSON string formatting with an official JSON serializer for error responses.
- Improves maintainability and prevents malformed JSON issues.