### PR TITLE
fix: Share DbContext instance across repositories via dependency injection

### DIFF
--- a/Backend/src/ITL.Domain/IUnitOfWork.cs
+++ b/Backend/src/ITL.Domain/IUnitOfWork.cs
@@ -6,7 +6,7 @@ namespace ITL.Domain;
 
 public interface IUnitOfWork : IDisposable
 {
-    IPermissionRepository PermissionRepository { get; set; }
-    IPermissionTypeRepository PermissionTypeRepository { get; set; }
+    IPermissionRepository PermissionRepository { get; }
+    IPermissionTypeRepository PermissionTypeRepository { get; }
     Task<int> SaveAsync();
 }

--- a/Backend/src/ITL.Infrastructure/Extensions/UnitOfWorkExtension.cs
+++ b/Backend/src/ITL.Infrastructure/Extensions/UnitOfWorkExtension.cs
@@ -1,4 +1,5 @@
 using ITL.Domain;
+using ITL.Domain.Repositories;
 using ITL.Infrastructure.Database;
 using Microsoft.Extensions.DependencyInjection;
 using System.Diagnostics.CodeAnalysis;
@@ -9,17 +10,10 @@ public static class UnitOfWorkExtension
 {
     public static IServiceCollection SetupUnitOfWork([NotNullAttribute] this IServiceCollection serviceCollection)
     {
-        //TODO: Find a way to inject the repositories and share the same context without creating a instance.
-        serviceCollection.AddScoped<IUnitOfWork, UnitOfWork>(f =>
-        {
-            var scopeFactory = f.GetRequiredService<IServiceScopeFactory>();
-            var context = f.GetService<KCTestContext>();
-            return new UnitOfWork(
-                context,
-                new PermissionRepository(context.Permissions),
-                new PermissionTypeRepository(context.PermissionTypes)
-            );
-        });
+        // Register repositories with DI, sharing the same DbContext instance
+        serviceCollection.AddScoped<IPermissionRepository, PermissionRepository>();
+        serviceCollection.AddScoped<IPermissionTypeRepository, PermissionTypeRepository>();
+        serviceCollection.AddScoped<IUnitOfWork, UnitOfWork>();
         return serviceCollection;
     }
 }

--- a/Backend/src/ITL.Infrastructure/Repositories/PermissionRepository.cs
+++ b/Backend/src/ITL.Infrastructure/Repositories/PermissionRepository.cs
@@ -1,12 +1,13 @@
 ﻿using ITL.Domain.Entities;
 using ITL.Domain.Repositories;
+using ITL.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 
 namespace ITL.Infrastructure.Repositories;
 
 public class PermissionRepository : Repository<Permission>, IPermissionRepository
 {
-    public PermissionRepository(DbSet<Permission> permissions) : base (permissions)
+    public PermissionRepository(KCTestContext context) : base(context.Permissions)
     {
     }
 }

--- a/Backend/src/ITL.Infrastructure/Repositories/PermissionTypeRepository.cs
+++ b/Backend/src/ITL.Infrastructure/Repositories/PermissionTypeRepository.cs
@@ -1,12 +1,13 @@
 ﻿using ITL.Domain.Entities;
 using ITL.Domain.Repositories;
+using ITL.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 
 namespace ITL.Infrastructure.Repositories;
 
 public class PermissionTypeRepository : Repository<PermissionType>, IPermissionTypeRepository
 {
-    public PermissionTypeRepository(DbSet<PermissionType> permissionTypes) : base(permissionTypes)
+    public PermissionTypeRepository(KCTestContext context) : base(context.PermissionTypes)
     {
     }
 }

--- a/Backend/src/ITL.Infrastructure/UnitOfWork.cs
+++ b/Backend/src/ITL.Infrastructure/UnitOfWork.cs
@@ -7,15 +7,14 @@ namespace ITL.Infrastructure;
 
 public class UnitOfWork : IUnitOfWork
 {
-    public IPermissionRepository PermissionRepository { get; set; }
-    public IPermissionTypeRepository PermissionTypeRepository { get; set; }
+    public IPermissionRepository PermissionRepository { get; }
+    public IPermissionTypeRepository PermissionTypeRepository { get; }
 
     private readonly KCTestContext _kCTestContext;
 
     public UnitOfWork(KCTestContext kCTestContext, IPermissionRepository permissionRepository, IPermissionTypeRepository permissionTypeRepository)
     {
         _kCTestContext = kCTestContext;
-
         PermissionRepository = permissionRepository;
         PermissionTypeRepository = permissionTypeRepository;
     }


### PR DESCRIPTION
Closes #267

- Registers DbContext and repositories as Scoped, ensuring a shared context per HTTP request.
- Ensures efficient resource usage and prevents multiple context instantiations.