### PR TITLE
fix: BadGateway status code enum

### DIFF
--- a/Backend/src/ITL.Domain/Common/Response.cs
+++ b/Backend/src/ITL.Domain/Common/Response.cs
@@ -13,7 +13,7 @@ public enum HttpStatusCode
     Conflict = 409,
     TooEarly = 425,
     InternalServerError = 500,
-    BadGateway = 501,
+    BadGateway = 502,
     ServiceUnavailable = 503,
     HTTPVersionNotSupported = 505
 }


### PR DESCRIPTION
### General
Changed the HTTP status code enum value for `BadGateway` from 501 to 502.

### Type
- [x] Fix

### Describe the changes here (summarized)
Updated `BadGateway` enum value in `Response.cs`

------
https://chatgpt.com/codex/tasks/task_e_6840b24f78a08323bbc402ef195cf2ee