### PR TITLE
Fix typo in webpack prod config comment

### DIFF
--- a/kctest-frontend/build/webpack.prod.conf.js
+++ b/kctest-frontend/build/webpack.prod.conf.js
@@ -102,7 +102,7 @@ const webpackConfig = merge(baseWebpackConfig, {
       name: 'manifest',
       minChunks: Infinity
     }),
-    // This instance extracts shared chunks from code splitted chunks and bundles them
+    // This instance extracts shared chunks from code split chunks and bundles them
     // in a separate chunk, similar to the vendor chunk
     // see: https://webpack.js.org/plugins/commons-chunk-plugin/#extra-async-commons-chunk
     new webpack.optimize.CommonsChunkPlugin({


### PR DESCRIPTION
## Summary
- fix typo in `webpack.prod.conf.js` comment

## Testing
- `npm run unit` *(fails: Vue packages version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6842f541c98c83239e67faeb459812ec