### PR TITLE
docs: fix step numbering in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Data validation using [FluentValidation](https://github.com/JeremySkinner/Fluent
 
 1. Create empty database, name: **`KCTest`**.
 2. Execute [migrations](https://github.com/Jadhielv/ITL/tree/master/Backend/src/ITL.Infrastructure/Migrations).
-2. Set connection string (in [appsettings.json](https://github.com/Jadhielv/ITL/blob/master/Backend/src/ITL.API/appsettings.json) or by user secrets mechanism).
-3. Run .. .
+3. Set connection string (in [appsettings.json](https://github.com/Jadhielv/ITL/blob/master/Backend/src/ITL.API/appsettings.json) or by user secrets mechanism).
+4. Run .. .
 
 [(kctest-frontend)](https://github.com/Jadhielv/ITL/tree/master/kctest-frontend)
 


### PR DESCRIPTION
## Summary
- correct the numeric order in the backend run instructions
------
https://chatgpt.com/codex/tasks/task_e_6842f6e57edc8323ade8854b4bf4b9c7