### PR TITLE
feat: Enhance PermissionTypeService add test

### DIFF
--- a/Backend/src/ITL.Tests/Services/PermissionTypeServiceTests.cs
+++ b/Backend/src/ITL.Tests/Services/PermissionTypeServiceTests.cs
@@ -48,6 +48,13 @@ public class PermissionTypeServiceTests
         var service = new PermissionTypeService(unitOfWorkMock.Object, mapperMock.Object);
 
         var permissionType = new PermissionTypeDto { };
+        var expectedDto = new PermissionTypeDto();
+        var permissionTypeEntity = new PermissionType();
+
+        mapperMock.Setup(x => x.Map<PermissionType>(permissionType))
+            .Returns(permissionTypeEntity);
+        mapperMock.Setup(x => x.Map<PermissionTypeDto>(permissionTypeEntity))
+            .Returns(expectedDto);
 
         permissionTypeRepositoryMock.Setup(x => x.ExistAsync(It.IsAny<Expression<Func<PermissionType, bool>>>()))
             .ReturnsAsync(false);
@@ -56,9 +63,10 @@ public class PermissionTypeServiceTests
             .Returns(permissionTypeRepositoryMock.Object);
 
         // Act
-        await service.AddPermissionType(permissionType);
+        var result = await service.AddPermissionType(permissionType);
 
         // Assert
+        Assert.That(result, Is.EqualTo(expectedDto));
         permissionTypeRepositoryMock.Verify(x => x.AddAsync(It.IsAny<PermissionType>()));
         unitOfWorkMock.Verify(x => x.SaveAsync());
     }


### PR DESCRIPTION
## Summary
- improve `AddPermissionType_PermissionTypeDoesNotExist_Should_SavePermissionType` test to assert the returned `PermissionTypeDto`

------
https://chatgpt.com/codex/tasks/task_e_6842f8c7a7488323a749b42b8a9cf2c9