### PR TITLE
fix: upgrade serialize-javascript to 7.0.5

### DIFF
--- a/kctest-frontend/package-lock.json
+++ b/kctest-frontend/package-lock.json
@@ -17072,9 +17072,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/kctest-frontend/package.json
+++ b/kctest-frontend/package.json
@@ -93,7 +93,7 @@
     "tmp": "^0.2.5",
     "cross-spawn": "7.0.6",
     "babel-traverse": "npm:@babel/traverse@^7.23.2",
-    "serialize-javascript": "^7.0.4",
+    "serialize-javascript": "^7.0.5",
     "json5": "^2.2.2",
     "loader-utils": "^2.0.4",
     "postcss": "^8.4.49",


### PR DESCRIPTION
Upgraded `serialize-javascript` to version `7.0.5` in `kctest-frontend/package.json` overrides to resolve a CPU Exhaustion Denial of Service vulnerability (CVE-2024-42475). Verified that all instances of the package in `package-lock.json` are updated and that existing frontend tests pass.

---
*PR created automatically by Jules for task [5288597404255069841](https://jules.google.com/task/5288597404255069841) started by @Jadhielv*