### PR TITLE
fix(frontend): upgrade lodash to 4.18.1 to resolve security vulnerability

### DIFF
--- a/kctest-frontend/package-lock.json
+++ b/kctest-frontend/package-lock.json
@@ -2842,13 +2842,14 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-util/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -13976,9 +13977,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/kctest-frontend/package.json
+++ b/kctest-frontend/package.json
@@ -90,6 +90,7 @@
     "webpack-merge": "^4.2.2"
   },
   "overrides": {
+    "lodash": "^4.18.0",
     "tmp": "^0.2.5",
     "cross-spawn": "7.0.6",
     "babel-traverse": "npm:@babel/traverse@^7.23.2",


### PR DESCRIPTION
This PR upgrades the `lodash` package in the `kctest-frontend` directory to version `4.18.1`. 

Lodash versions 4.17.23 and earlier are vulnerable to prototype pollution in the `_.unset` and `_.omit` functions. This fix ensures all transitive occurrences of `lodash` are updated to a secure version using the `overrides` field in `package.json`.

Changes:
- Modified `kctest-frontend/package.json` to include `"lodash": "^4.18.0"` in the `overrides` object.
- Updated `kctest-frontend/package-lock.json` by running `npm install --legacy-peer-deps`.
- Verified the upgrade using `npm list lodash`.
- Ensured all frontend unit tests pass.

---
*PR created automatically by Jules for task [10596748928863996996](https://jules.google.com/task/10596748928863996996) started by @Jadhielv*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution configuration for improved package management consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->