### PR TITLE
Upgrade follow-redirects to 1.16.0 to fix header leakage vulnerability

### DIFF
--- a/kctest-frontend/package-lock.json
+++ b/kctest-frontend/package-lock.json
@@ -9338,9 +9338,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/kctest-frontend/package.json
+++ b/kctest-frontend/package.json
@@ -90,6 +90,7 @@
     "webpack-merge": "^4.2.2"
   },
   "overrides": {
+    "follow-redirects": "^1.16.0",
     "lodash": "^4.18.0",
     "tmp": "^0.2.5",
     "cross-spawn": "7.0.6",


### PR DESCRIPTION
Upgraded transitive dependency follow-redirects to version 1.16.0 via overrides in package.json to address a security vulnerability where custom authentication headers could leak during cross-domain redirects. Verified the update in package-lock.json and ensured that unit tests pass.

---
*PR created automatically by Jules for task [2466345369906593036](https://jules.google.com/task/2466345369906593036) started by @Jadhielv*