### PR TITLE
fix: upgrade uuid to v14.0.0 to fix security vulnerability

### DIFF
--- a/kctest-frontend/package-lock.json
+++ b/kctest-frontend/package-lock.json
@@ -18881,13 +18881,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/kctest-frontend/package.json
+++ b/kctest-frontend/package.json
@@ -90,6 +90,7 @@
     "webpack-merge": "^4.2.2"
   },
   "overrides": {
+    "uuid": "^14.0.0",
     "follow-redirects": "^1.16.0",
     "lodash": "^4.18.0",
     "tmp": "^0.2.5",


### PR DESCRIPTION
This PR addresses a security vulnerability in the `uuid` package (GHSA-w5hq-g745-h8pq) which involves a missing buffer bounds check in versions v3, v5, and v6.

Changes:
- Added `uuid: ^14.0.0` to the `overrides` field in `kctest-frontend/package.json` to force transitive dependencies to use the patched version.
- Updated `kctest-frontend/package-lock.json` by running `npm install --legacy-peer-deps`.
- Verified that `uuid` version 14.0.0 is correctly used by dependencies like `node-notifier` and `webpack-dev-server`.
- Confirmed that frontend unit tests continue to pass.

---
*PR created automatically by Jules for task [8350574005503452201](https://jules.google.com/task/8350574005503452201) started by @Jadhielv*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency version constraints to ensure consistent package resolution across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->