### PR TITLE
Upgrade postcss to fix XSS vulnerability

### DIFF
--- a/kctest-frontend/package-lock.json
+++ b/kctest-frontend/package-lock.json
@@ -15430,9 +15430,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",

--- a/kctest-frontend/package.json
+++ b/kctest-frontend/package.json
@@ -99,7 +99,7 @@
     "serialize-javascript": "^7.0.5",
     "json5": "^2.2.2",
     "loader-utils": "^2.0.4",
-    "postcss": "^8.4.49",
+    "postcss": "^8.5.10",
     "minimatch": "^3.1.5",
     "editorconfig": {
       "minimatch": "^9.0.7"


### PR DESCRIPTION
Upgraded `postcss` to version `8.5.12` to fix an XSS vulnerability (GHSA-7fh5-6m66-3pq3). The upgrade was performed by updating the `overrides` field in `kctest-frontend/package.json` and regenerating the lockfile. Verified the version with `npm list` and ensured all unit tests pass.

---
*PR created automatically by Jules for task [12092359439014677617](https://jules.google.com/task/12092359439014677617) started by @Jadhielv*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tool dependency to a newer compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->