### PR TITLE
fix: resolve http-proxy-middleware and path-to-regexp vulnerabilities

### DIFF
--- a/kctest-frontend/package-lock.json
+++ b/kctest-frontend/package-lock.json
@@ -2941,6 +2941,19 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@jest/environment-jsdom-abstract/node_modules/pretty-format": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
@@ -10200,9 +10213,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15149,9 +15162,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "dev": true,
       "license": "MIT"
     },

--- a/kctest-frontend/package.json
+++ b/kctest-frontend/package.json
@@ -126,7 +126,9 @@
     "js-yaml": "^4.2.0",
     "@istanbuljs/load-nyc-config": {
       "js-yaml": "^3.14.2"
-    }
+    },
+    "http-proxy-middleware": "^2.0.10",
+    "path-to-regexp": "^0.1.13"
   },
   "engines": {
     "node": ">= 18.0.0",


### PR DESCRIPTION
Resolved GHSA-64mm-vxmg-q3vj and GHSA-37ch-88jc-xwx2 by using package overrides for http-proxy-middleware and path-to-regexp in the kctest-frontend project. This ensures that the patched versions are used throughout the dependency tree without causing regressions or forced downgrades of other major packages.

---
*PR created automatically by Jules for task [1439785371852871684](https://jules.google.com/task/1439785371852871684) started by @Jadhielv*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency overrides to use newer, fixed versions of two packages, helping improve build stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->