### PR TITLE
fix: resolve memory exhaustion DoS in ws (CVE-2024-37890)

### DIFF
--- a/kctest-frontend/package-lock.json
+++ b/kctest-frontend/package-lock.json
@@ -2941,6 +2941,19 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@jest/environment-jsdom-abstract/node_modules/pretty-format": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
@@ -19075,9 +19088,9 @@
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/kctest-frontend/package.json
+++ b/kctest-frontend/package.json
@@ -123,6 +123,9 @@
     "jest-environment-jsdom": {
       "picomatch": "^4.0.4"
     },
+    "webpack-bundle-analyzer": {
+      "ws": "^7.5.11"
+    },
     "js-yaml": "^4.3.0",
     "@istanbuljs/load-nyc-config": {
       "js-yaml": "^3.15.0"


### PR DESCRIPTION
Resolved high-severity memory exhaustion DoS vulnerability in transitive dependency 'ws' under 'kctest-frontend/'. Configured a nested override in package.json to force webpack-bundle-analyzer to use ws@^7.5.11, and regenerated package-lock.json accordingly.

---
*PR created automatically by Jules for task [4534617043812806854](https://jules.google.com/task/4534617043812806854) started by @Jadhielv*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency resolution to improve compatibility and stability during application builds.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->