### PR TITLE
fix: upgrade postcss-selector-parser to address CVE-2026-9358

### DIFF
--- a/kctest-frontend/package-lock.json
+++ b/kctest-frontend/package-lock.json
@@ -15595,9 +15595,9 @@
       }
     },
     "node_modules/postcss-modules-local-by-default/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+      "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15625,9 +15625,9 @@
       }
     },
     "node_modules/postcss-modules-scope/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+      "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/kctest-frontend/package.json
+++ b/kctest-frontend/package.json
@@ -139,7 +139,13 @@
     "browserslist": "^4.28.7",
     "fast-uri": "^3.1.6",
     "decode-uri-component": "^0.5.0",
-    "postcss-selector-parser": "^6.1.3"
+    "postcss-selector-parser": "^6.1.3",
+    "postcss-modules-local-by-default": {
+      "postcss-selector-parser": "^7.1.3"
+    },
+    "postcss-modules-scope": {
+      "postcss-selector-parser": "^7.1.3"
+    }
   },
   "engines": {
     "node": ">= 18.0.0",


### PR DESCRIPTION
Fixes Dependabot alert #187 (CVE-2026-9358) by updating npm overrides in `kctest-frontend/package.json` for `postcss-selector-parser` under `postcss-modules-local-by-default` and `postcss-modules-scope` to `^7.1.3`.

---
*PR created automatically by Jules for task [2213687087795467426](https://jules.google.com/task/2213687087795467426) started by @Jadhielv*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build configuration to improve compatibility and consistency for stylesheet processing.
  - No user-facing functionality or public APIs were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->